### PR TITLE
Adding Diffusers v0.11.0

### DIFF
--- a/recipe/build_base.bat
+++ b/recipe/build_base.bat
@@ -1,0 +1,1 @@
+%PYTHON% -m pip install . -vv

--- a/recipe/build_base.bat
+++ b/recipe/build_base.bat
@@ -1,1 +1,0 @@
-%PYTHON% -m pip install . -vv

--- a/recipe/build_base.sh
+++ b/recipe/build_base.sh
@@ -1,0 +1,1 @@
+$PYTHON -m pip install . -vv

--- a/recipe/build_base.sh
+++ b/recipe/build_base.sh
@@ -1,1 +1,0 @@
-$PYTHON -m pip install . -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "diffusers" %}
-{% set version = "0.7.2" %}
+{% set version = "0.11.0" %}
 
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: fb814ffd150cc6f470380b8c6a521181a77beb2f44134d2aad2e4cd8aa2ced0e
+  sha256: 553978badef3bb95af7557679f037a3f01cc167e9991fd9618578d3971cd62f6
 
 build:
   number: 0
@@ -43,7 +43,7 @@ outputs:
         - huggingface_hub >=0.10.0
         - importlib-metadata
         - numpy
-        - pillow <10.0
+        - pillow
         - regex !=2019.12.17
         - requests
 
@@ -82,7 +82,7 @@ outputs:
         - python
         - {{ pin_subpackage(name+'-base', exact=True) }}
         - pytorch >=1.4
-        - huggingface_accelerate
+        - huggingface_accelerate >=0.11.0
     test:
       imports:
         - diffusers

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,6 @@ build:
   number: 0
   # accelerate not yet available on OSX or Windows
   skip: true  # [py<37 or osx or win]
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 outputs:
   - name: {{ name }}-base

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,15 +12,17 @@ source:
 
 build:
   number: 0
-  noarch: python
+  skip: true  # [py<37]
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
     - pip
-    - python >=3.6
+    - python
+    - setuptools
+    - wheel
   run:
-    - python >=3.6
+    - python
     - filelock
     - huggingface_hub
     - importlib-metadata

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -97,6 +97,28 @@ outputs:
       requires:
         - pip
 
+  - name: diffusers
+    script: build_base.sh  # [not win]
+    build:
+      skip: true  # [win]
+    requirements:
+      host:
+        - pip
+        - python
+        - setuptools
+        - wheel
+      run:
+        - {{ pin_subpackage(name+'-torch', exact=True) }}
+    test:
+      imports:
+        - diffusers
+        - diffusers.models
+      commands:
+        - pip check
+        - diffusers-cli --help
+      requires:
+        - pip
+
 about:
   home: https://github.com/huggingface/diffusers
   license: Apache-2.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -60,7 +60,7 @@ outputs:
       run:
         - {{ pin_subpackage(name+'-base', exact=True) }}
         - pytorch >=1.4
-        # - accelerate # TODO still needs built
+        - huggingface_accelerate
     test:
       imports:
         - diffusers

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,12 +21,22 @@ outputs:
     script: build_base.bat  # [win]
     build:
       skip: true  # [py<37 or osx or win]
+      missing_dso_whitelist:
+        - /lib64/libc.so.6
+        - /lib64/libpthread.so.0
+        - /lib64/libgcc_s.so.1
+        - /lib64/libm.so.6
+        - $RPATH/libgfortran.so.5
+        - /lib64/librt.so.1
+        - $RPATH/libgomp.so.1
     requirements:
       host:
         - pip
         - python
         - setuptools
         - wheel
+        - pillow
+        - numpy
       run:
         - python
         - filelock
@@ -52,13 +62,24 @@ outputs:
     script: build_base.bat  # [win]
     build:
       skip: true  # [py<37]
+      missing_dso_whitelist:
+        - /lib64/libc.so.6
+        - /lib64/libpthread.so.0
+        - /lib64/libgcc_s.so.1
+        - /lib64/libm.so.6
+        - $RPATH/libgfortran.so.5
+        - /lib64/librt.so.1
+        - $RPATH/libgomp.so.1
     requirements:
       host:
         - pip
         - python
         - setuptools
         - wheel
+        - pillow
+        - numpy
       run:
+        - python
         - {{ pin_subpackage(name+'-base', exact=True) }}
         - pytorch >=1.4
         - huggingface_accelerate
@@ -102,13 +123,24 @@ outputs:
     script: build_base.sh  # [not win]
     build:
       skip: true  # [win]
+      missing_dso_whitelist:
+        - /lib64/libc.so.6
+        - /lib64/libpthread.so.0
+        - /lib64/libgcc_s.so.1
+        - /lib64/libm.so.6
+        - $RPATH/libgfortran.so.5
+        - /lib64/librt.so.1
+        - $RPATH/libgomp.so.1
     requirements:
       host:
         - pip
         - python
         - setuptools
         - wheel
+        - pillow
+        - numpy
       run:
+        - python
         - {{ pin_subpackage(name+'-torch', exact=True) }}
     test:
       imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,7 @@ build:
   number: 0
   # accelerate not yet available on OSX or Windows
   skip: true  # [py<37 or osx or win]
+  script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 outputs:
   - name: {{ name }}-base

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,14 +12,15 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<37]
+  # accelerate not yet available on OSX or Windows
+  skip: true  # [py<37 or osx or win]
 
 outputs:
   - name: {{ name }}-base
     script: build_base.sh  # [not win]
     script: build_base.bat  # [win]
     build:
-      skip: true  # [py<37]
+      skip: true  # [py<37 or osx or win]
     requirements:
       host:
         - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -156,8 +156,7 @@ about:
   home: https://github.com/huggingface/diffusers
   license: Apache-2.0
   license_file: LICENSE
-  license_family: "Apache"
-  license_url: https://github.com/huggingface/diffusers/blob/v{{ version }}/LICENSE
+  license_family: Apache
   summary: Diffusers provides pretrained vision diffusion models, and serves as a modular toolbox for inference and training.
   description: |
     :hugs: Diffusers provides pretrained diffusion models across multiple modalities, 
@@ -167,7 +166,6 @@ about:
     PyPI: [https://pypi.org/project/diffusers/](https://pypi.org/project/diffusers/)
 
   doc_url: https://huggingface.co/docs/diffusers/index
-  doc_source_url: https://github.com/huggingface/diffusers/tree/main/docs/source
   dev_url: https://github.com/huggingface/diffusers
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -83,7 +83,6 @@ outputs:
         - wheel
       run:
         - {{ pin_subpackage(name+'-base', exact=True) }}
-        # TODO: None of these exist
         - jax
         - jaxlib
         - flax

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -71,30 +71,31 @@ outputs:
       requires:
         - pip
 
-  - name: diffusers-flax
-    script: build_base.sh  # [not win]
-    build:
-      skip: true  # [win]
-    requirements:
-      host:
-        - pip
-        - python
-        - setuptools
-        - wheel
-      run:
-        - {{ pin_subpackage(name+'-base', exact=True) }}
-        - jax >=0.2.8,!=0.3.2
-        - jaxlib >=0.1.65
-        - flax
-    test:
-      imports:
-        - diffusers
-        - diffusers.models
-      commands:
-        - pip check
-        - diffusers-cli --help
-      requires:
-        - pip
+  ## TODO: Enable once the flax toolchain is flushed out. 
+  # - name: diffusers-flax
+  #   script: build_base.sh  # [not win]
+  #   build:
+  #     skip: true  # [win]
+  #   requirements:
+  #     host:
+  #       - pip
+  #       - python
+  #       - setuptools
+  #       - wheel
+  #     run:
+  #       - {{ pin_subpackage(name+'-base', exact=True) }}
+  #       - jax >=0.2.8,!=0.3.2
+  #       - jaxlib >=0.1.65
+  #       - flax
+  #   test:
+  #     imports:
+  #       - diffusers
+  #       - diffusers.models
+  #     commands:
+  #       - pip check
+  #       - diffusers-cli --help
+  #     requires:
+  #       - pip
 
   - name: diffusers
     script: build_base.sh  # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,46 +3,99 @@
 
 
 package:
-  name: {{ name|lower }}
+  name: {{ name|lower }}-suite
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/diffusers-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: fb814ffd150cc6f470380b8c6a521181a77beb2f44134d2aad2e4cd8aa2ced0e
 
 build:
   number: 0
   skip: true  # [py<37]
-  script: {{ PYTHON }} -m pip install . -vv
-  entry_points:
-    - diffusers-cli=diffusers.commands.diffusers_cli:main
 
-requirements:
-  host:
-    - pip
-    - python
-    - setuptools
-    - wheel
-  run:
-    - python
-    - filelock
-    - huggingface_hub >=0.10.0
-    - importlib-metadata
-    - numpy
-    - pillow <10.0
-    - regex !=2019.12.17
-    - requests
-    - pytorch >=1.4
+outputs:
+  - name: {{ name }}-base
+    script: build_base.sh  # [not win]
+    script: build_base.bat  # [win]
+    build:
+      skip: true  # [py<37]
+    requirements:
+      host:
+        - pip
+        - python
+        - setuptools
+        - wheel
+      run:
+        - python
+        - filelock
+        - huggingface_hub >=0.10.0
+        - importlib-metadata
+        - numpy
+        - pillow <10.0
+        - regex !=2019.12.17
+        - requests
 
-test:
-  imports:
-    - diffusers
-    - diffusers.models
-  commands:
-    - pip check
-    - diffusers-cli --help
-  requires:
-    - pip
+    test:
+      imports:
+        - diffusers
+        - diffusers.models
+      commands:
+        - pip check
+        - diffusers-cli --help
+      requires:
+        - pip
+
+  - name: diffusers-torch
+    script: build_base.sh  # [not win]
+    script: build_base.bat  # [win]
+    build:
+      skip: true  # [py<37]
+    requirements:
+      host:
+        - pip
+        - python
+        - setuptools
+        - wheel
+      run:
+        - {{ pin_subpackage(name+'-base', exact=True) }}
+        - pytorch >=1.4
+        # - accelerate # TODO still needs built
+    test:
+      imports:
+        - diffusers
+        - diffusers.models
+      commands:
+        - pip check
+        - diffusers-cli --help
+      requires:
+        - pip
+
+  - name: diffusers-flax
+    script: build_base.sh  # [not win]
+    build:
+      skip: true  # [win]
+    requirements:
+      host:
+        - pip
+        - python
+        - setuptools
+        - wheel
+      run:
+        - {{ pin_subpackage(name+'-base', exact=True) }}
+        # TODO: None of these exist
+        - jax
+        - jaxlib
+        - flax
+    test:
+      imports:
+        - diffusers
+        - diffusers.models
+      commands:
+        - pip check
+        - diffusers-cli --help
+      requires:
+        - pip
 
 about:
   home: https://github.com/huggingface/diffusers

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,9 +43,11 @@ test:
 
 about:
   home: https://github.com/huggingface/diffusers
-  summary: Diffusers
   license: Apache-2.0
   license_file: LICENSE
+  license_family: "Apache"
+  license_url: https://github.com/huggingface/diffusers/blob/v{{ version }}/LICENSE
+  summary: Diffusers provides pretrained vision diffusion models, and serves as a modular toolbox for inference and training.
   description: |
     :hugs: Diffusers provides pretrained diffusion models across multiple modalities, 
     such as vision and audio, and serves as a modular toolbox for inference and 
@@ -53,7 +55,8 @@ about:
 
     PyPI: [https://pypi.org/project/diffusers/](https://pypi.org/project/diffusers/)
 
-  doc_url: https://github.com/huggingface/diffusers
+  doc_url: https://huggingface.co/docs/diffusers/index
+  doc_source_url: https://github.com/huggingface/diffusers/tree/main/docs/source
   dev_url: https://github.com/huggingface/diffusers
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,10 +26,10 @@ requirements:
   run:
     - python
     - filelock
-    - huggingface_hub
+    - huggingface_hub >=0.10.0
     - importlib-metadata
     - numpy
-    - pillow
+    - pillow <10.0
     - regex !=2019.12.17
     - requests
     - pytorch >=1.4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -83,8 +83,8 @@ outputs:
         - wheel
       run:
         - {{ pin_subpackage(name+'-base', exact=True) }}
-        - jax
-        - jaxlib
+        - jax >=0.2.8,!=0.3.2
+        - jaxlib >=0.1.65
         - flax
     test:
       imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,8 @@ build:
   number: 0
   skip: true  # [py<37]
   script: {{ PYTHON }} -m pip install . -vv
+  entry_points:
+    - diffusers-cli=diffusers.commands.diffusers_cli:main
 
 requirements:
   host:
@@ -38,6 +40,7 @@ test:
     - diffusers.models
   commands:
     - pip check
+    - diffusers-cli --help
   requires:
     - pip
 


### PR DESCRIPTION
#  Diffusers v0.11.0
Upstream: https://github.com/huggingface/diffusers/tree/v0.11.0
Jira: https://anaconda.atlassian.net/browse/PKG-679
`setup.py`: https://github.com/huggingface/diffusers/blob/v0.11.0/setup.py#L209

## Changes
- Initial fork from `conda-forge`
- Remove `noarch`
- Update about section
- Update dependency pinnings

## Notes
- This is a new package for defaults
- `diffusers` supports a `torch` and `flax` variant. This recipe was setup to be able to eventually produce both, but currently only supports `torch`