### PR TITLE
V0.32.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/abs.yaml
+++ b/abs.yaml
@@ -4,3 +4,4 @@ build_env_vars:
 channels:
   - https://staging.continuum.io/prefect/fs/safetensors-feedstock/pr9/c8e46a9
   - https://staging.continuum.io/prefect/fs/huggingface_hub-feedstock/pr9/8468f66
+  - https://staging.continuum.io/prefect/fs/accelerate-feedstock/pr7/4b4512f

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,6 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313 : yes
+
+channels:
+  - https://staging.continuum.io/prefect/fs/safetensors-feedstock/pr9/c8e46a9
+  - https://staging.continuum.io/prefect/fs/huggingface_hub-feedstock/pr9/8468f66

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,7 +1,2 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313 : yes
-
-channels:
-  - https://staging.continuum.io/prefect/fs/safetensors-feedstock/pr9/c8e46a9
-  - https://staging.continuum.io/prefect/fs/huggingface_hub-feedstock/pr9/8468f66
-  - https://staging.continuum.io/prefect/fs/accelerate-feedstock/pr7/4b4512f

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ outputs:
       run:
         - python
         - filelock
-        - huggingface_hub >=0.27.0
+        - huggingface_hub >=0.23.2
         - importlib-metadata
         - numpy
         - pillow

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "diffusers" %}
-{% set version = "0.30.3" %}
+{% set version = "0.32.2" %}
 
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 67c5eb25d5b50bf0742624ef43fe0f6d1e1604f64aad3e8558469cbe89ecf72f
+  sha256: eb1e36b326aabb0675729af7c626caf7a76ce7ced3a126e879331790b1eaa230
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ outputs:
       run:
         - python
         - filelock
-        - huggingface_hub >=0.23.2
+        - huggingface_hub >=0.27.0
         - importlib-metadata
         - numpy
         - pillow


### PR DESCRIPTION
diffusers v0.32.2
**Destination channel:**  defaults

### Links

- [PKG-7174](https://anaconda.atlassian.net/browse/PKG-7174) 
- [Upstream repository](https://github.com/huggingface/diffusers/tree/v0.32.2)
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/safetensors-feedstock/pull/9
  - https://github.com/AnacondaRecipes/accelerate-feedstock/pull/7
  - https://github.com/AnacondaRecipes/huggingface_hub-feedstock/pull/9

### Explanation of changes:

- Bump version and SHA
- Adjust huggingface_hub dependency pinning
- Build for python 3.13


[PKG-7176]: https://anaconda.atlassian.net/browse/PKG-7176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PKG-7174]: https://anaconda.atlassian.net/browse/PKG-7174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ