### PR TITLE
diffusers 0.36.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "diffusers" %}
-{% set version = "0.35.2" %}
+{% set version = "0.36.0" %}
 
 package:
   name: {{ name|lower }}-suite
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 30ecd552303edfcfe1724573c3918a8462ee3ab4d529bdbd4c0045f763affded
+  sha256: a9cde8721b415bde6a678f2d02abb85396487e1b0e0d2b4abb462d14a9825ab0
 
 build:
   number: 0
@@ -31,7 +31,8 @@ outputs:
         - python
         - importlib-metadata
         - filelock
-        - huggingface_hub >=0.34.0
+        - httpx <1.0.0
+        - huggingface_hub >=0.34.0,<2.0
         - numpy
         - regex !=2019.12.17
         - requests


### PR DESCRIPTION
diffusers 0.36.0 

**Destination channel:** Defaults

### Links

- [PKG-12452]
- dev_url:        https://github.com/huggingface/diffusers/tree/v0.36.0
- conda_forge:    https://github.com/conda-forge/diffusers-feedstock
- pypi:           https://pypi.org/project/diffusers/0.36.0
- pypi inspector: https://inspector.pypi.io/project/diffusers/0.36.0

### Explanation of changes:

- new version number


[PKG-12452]: https://anaconda.atlassian.net/browse/PKG-12452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ